### PR TITLE
Update gulpfile to allow subdirectories

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@ gulp.task('clean', function() {
 });
 
 gulp.task('renameSources', function() {
-  return gulp.src(['*.html', '*.php'])
+  return gulp.src(['*.html', '**/*.php', '!dist', '!dist/**'])
     .pipe(htmlreplace({
       'js': 'assets/js/main.min.js',
       'css': 'assets/css/main.min.css'


### PR DESCRIPTION
Update gulpfile to allow subdirectories for .php files and exclude the "dist" directory so you don't end up with a duplicated dist/dist directory